### PR TITLE
Match user address with polling station address

### DIFF
--- a/src/ClientApp/src/app/app.module.ts
+++ b/src/ClientApp/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { TranslateModule, TranslateLoader } from '@ngx-translate/core';
 import { JoinTranslationsPipe } from './join-translations.pipe';
 import { MapPsDetailsComponent } from './polling-station-search/map-ps-details/map-ps-details.component';
+import { PollingStationMatcherService } from './services/polling-station-matcher.service';
 
 const appRoutes: Routes = [
   { path: '', component: HomeComponent, pathMatch: 'full' },
@@ -80,7 +81,8 @@ const appRoutes: Routes = [
   ],
   providers: [
     HereAddressService,
-    DataService
+    DataService,
+    PollingStationMatcherService,
   ],
   bootstrap: [AppComponent]
 })

--- a/src/ClientApp/src/app/polling-station-search/polling-station-search.component.html
+++ b/src/ClientApp/src/app/polling-station-search/polling-station-search.component.html
@@ -23,21 +23,31 @@
     </div>
   </form>
 
-  <div class="container" *ngIf="pollingStations">
-    <p class="text-padding"><b>Dacă ești cetățean cu domiciliul în orașul în care dorești să votezi aceasta este secția
-        dedicată unde poți vota:</b></p>
-    <app-polling-station-card-info [pollingStation]="pollingStations[0]" [distance]="1" [lightTheme]="true"
-      class="ps-item margin-bottom-80">
-    </app-polling-station-card-info>
+  <div *ngIf="pollingStations" class="container">
+    <div *ngIf="pollingStationsForAddress.length > 0">
+      <p class="text-padding"><b>Dacă ești cetățean cu domiciliul în orașul în care dorești să votezi aceasta este
+        secția dedicată unde poți vota:</b></p>
+
+      <div class="ps-list">
+        <app-polling-station-card-info *ngFor="let pollingStation of pollingStationsForAddress"
+                                       [distance]="1" [lightTheme]="true" [pollingStation]="pollingStation"
+                                       class="ps-item margin-bottom-80">
+        </app-polling-station-card-info>
+      </div>
+    </div>
 
     <div class="text-padding">
-      <p><b>Dacă nu ai domiciliul permanent la adresa menționată poți vota în oricare dintre secțiile din oraș. Cele mai
-          apropiate secții de tine sunt:</b></p>
+      <p *ngIf="pollingStationsForAddress.length === 0">
+        <b>Nu am găsit strada introdusă.</b>
+      </p>
+      <p><b>Dacă nu ai domiciliul permanent la adresa menționată poți vota în oricare dintre secțiile din oraș.</b></p>
+      <p><b>Cele mai apropiate secții de tine sunt:</b></p>
     </div>
 
     <div class="ps-list">
-      <app-polling-station-card-info *ngFor="let pollingStation of pollingStations | slice:1"
-        [pollingStation]="pollingStation" [lightTheme]="false" [distance]="1" class="ps-item">
+      <app-polling-station-card-info *ngFor="let pollingStation of pollingStations"
+                                     [distance]="1" [lightTheme]="false" [pollingStation]="pollingStation"
+                                     class="ps-item">
       </app-polling-station-card-info>
     </div>
   </div>

--- a/src/ClientApp/src/app/polling-station-search/polling-station-search.component.ts
+++ b/src/ClientApp/src/app/polling-station-search/polling-station-search.component.ts
@@ -17,6 +17,7 @@ import { getMapPins } from '../state/selectors';
 import { replace } from 'lodash';
 import { PollingStationGroup, PollingStation } from '../services/data.service';
 import { LoadLocations } from '../state/actions';
+import { PollingStationMatcherService } from '../services/polling-station-matcher.service';
 
 declare var H: any;
 export enum PinType {
@@ -37,6 +38,7 @@ export class PollingStationSearchComponent implements OnInit, AfterViewInit, OnD
   control = new FormControl();
   filteredAddresses: Observable<AddressSuggestion[]>;
   pollingStations: PollingStation[];
+  pollingStationsForAddress: PollingStation[];
   pollingStatationsGroup$: Subject<PollingStationGroup> = new Subject<PollingStationGroup>();
 
   private platform: any;
@@ -51,7 +53,9 @@ export class PollingStationSearchComponent implements OnInit, AfterViewInit, OnD
 
   private subscription: Subscription;
 
-  constructor(private addressSuggest: HereAddressService, private store: Store<ApplicationState>) {
+  constructor(private addressSuggest: HereAddressService,
+              private store: Store<ApplicationState>,
+              private pollingStationMatcher: PollingStationMatcherService) {
     this.platform = new H.service.Platform({
       apikey: hereMapsToken
     });
@@ -79,6 +83,7 @@ export class PollingStationSearchComponent implements OnInit, AfterViewInit, OnD
         const mapMarkers: any[] = [];
         mapMarkers.push(userAddressMarker);
         this.pollingStations = [].concat(...pollingStationsGroups.map(p => p.pollingStations));
+        this.pollingStationsForAddress = this.pollingStationMatcher.findPollingStation(this.pollingStations, userAddress.address);
         pollingStationsGroups.forEach(pollingStationGroup => {
           const pollingStationMarker = new H.map.Marker(
             {

--- a/src/ClientApp/src/app/services/polling-station-matcher.service.ts
+++ b/src/ClientApp/src/app/services/polling-station-matcher.service.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@angular/core';
+import { AssignedAddress, PollingStation } from './data.service';
+import { Address } from './here-address.service';
+
+@Injectable({providedIn: 'root'})
+export class PollingStationMatcherService {
+  private integralStreetToken = 'integral#';
+  private oddNumbersToken = 'numere impare nr.';
+  private evenNumbersToken = 'numere pare nr.';
+  private numbersSeparatorToken = '-';
+  private houseNumbersSeparatorToken = '#';
+
+  findPollingStation(pollingStations: PollingStation[], userAddress: Address): PollingStation[] {
+    return pollingStations.filter(pollingStation => {
+      const assignedAddresses = pollingStation.assignedAddresses;
+      const matchedAssignedAddress = assignedAddresses.find((assignedAddress) =>
+        this.isSameLocality(assignedAddress, userAddress) &&
+        this.isSameStreet(assignedAddress, userAddress) &&
+        this.isMatchingNumber(assignedAddress, userAddress));
+      return matchedAssignedAddress != null;
+    });
+  }
+
+  private isSameLocality(assignedAddress: AssignedAddress, userAddress: Address): boolean {
+    const assignedAddressLocality = this.normalize(assignedAddress.locality.toLowerCase());
+    const userAddressCity = this.normalize(userAddress.city.toLowerCase());
+    return assignedAddressLocality.includes(userAddressCity);
+  }
+
+  private isSameStreet(assignedAddress: AssignedAddress, userAddress: Address): boolean {
+    const userStreet = this.normalize(userAddress.street.toLowerCase());
+    const assignedAddressStreet = this.normalize(assignedAddress.street.toLowerCase());
+    return userStreet.includes(assignedAddressStreet) || assignedAddressStreet.includes(userStreet);
+  }
+
+  private isMatchingNumber(assignedAddress: AssignedAddress, userAddress: Address): boolean {
+    if (assignedAddress.houseNumbers === this.integralStreetToken) {
+      return true;
+    }
+
+    if (!userAddress.houseNumber) {
+      return true;
+    }
+
+    const assignedAddressHouseNumbers = assignedAddress.houseNumbers.split(this.houseNumbersSeparatorToken);
+    const matchedHouseNumber = assignedAddressHouseNumbers
+      .find(assignedAddressesHouseNumber => this.isHouseNumberMatch(assignedAddressesHouseNumber, userAddress.houseNumber));
+    return matchedHouseNumber != null;
+  }
+
+  private normalize(str: string) {
+    return str.normalize('NFKD').replace(/[^\w]/g, '');
+  }
+
+  private isHouseNumberMatch(assignedAddressesHouseNumber: string, houseNumberAsString: string) {
+    const houseNumber = +houseNumberAsString;
+    if (assignedAddressesHouseNumber.includes(this.evenNumbersToken)) {
+      return this.isMatchingEvenNumber(assignedAddressesHouseNumber, houseNumber);
+    }
+
+    if (assignedAddressesHouseNumber.includes(this.oddNumbersToken)) {
+      return this.isMatchingOddNumber(assignedAddressesHouseNumber, houseNumber);
+    }
+
+    return false;
+  }
+
+  private isMatchingEvenNumber(assignedAddressesHouseNumber: string, houseNumber: number) {
+    if (houseNumber % 2 !== 0) {
+      return false;
+    }
+
+    const numberRange = assignedAddressesHouseNumber.split(this.evenNumbersToken)[1];
+    const lowerLimit = +numberRange.split(this.numbersSeparatorToken)[0].trim();
+    const upperLimit = +numberRange.split(this.numbersSeparatorToken)[1].trim();
+
+    return lowerLimit <= houseNumber && houseNumber <= upperLimit;
+  }
+
+  private isMatchingOddNumber(assignedAddressesHouseNumber: string, houseNumber: number) {
+    if (houseNumber % 2 === 0) {
+      return false;
+    }
+
+    const numberRange = assignedAddressesHouseNumber.split(this.oddNumbersToken)[1];
+    const lowerLimit = +numberRange.split(this.numbersSeparatorToken)[0].trim();
+    const upperLimit = +numberRange.split(this.numbersSeparatorToken)[1].trim();
+    return lowerLimit <= houseNumber && houseNumber <= upperLimit;
+  }
+}


### PR DESCRIPTION
### What does it fix?

Closes #44 

Matches the user address with the correct polling station.

### How has it been tested?

For now, this implementation was tested manually for the following scenarios:
* User address without house number 
  * matches an unique polling station if the whole street is on the same polling station
  * matches multiple polling stations if the street is divided between multiple polling stations
* User address with house number
  * matches an unique polling station if the whole street is on the same polling station
  * matches an unique polling station if the street is divided between multiple polling stations and their house numbers are represented as `numere pare nr. 2 -8#`, `numere impare nr. 21 -69#` or combination of these 2.

### Usecases which currently don't work:
* when the house number of the user or one of the polling station address contains letters (e.g `6C`)
* when the house number of the polling station address contains information about block number since `here maps` doesn't autosuggest block number (e.g `nr. - bl. 7,bl. 8,bl. 32,bl. 47#`)
* custom house number of the polling station address (e.g `toate numerele din intervalul nr. 1 -43# nr. 173 -334#`)












